### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/icecoldfire/HomeAssistant-Waveshare-Relay/security/code-scanning/1](https://github.com/icecoldfire/HomeAssistant-Waveshare-Relay/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the least privileges required for the workflow. Based on the steps in the workflow:
- The `contents: read` permission is sufficient for most steps, such as checking out the code and installing dependencies.
- The `contents: write` permission is not required since the workflow does not modify repository contents.
- The `actions: read` permission is implicitly included and does not need to be specified.

We will add the `permissions` block at the top level of the workflow to apply it to all jobs (`test` and `validate`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
